### PR TITLE
Ny intern modell

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
@@ -31,6 +31,7 @@ data class TiltakspengerVedtak(
         TILTAKSPENGER,
         TILTAKSPENGER_OG_BARNETILLEGG,
         STANS,
+        AVSLAG,
     }
 
     fun oppdaterPeriode(nyPeriode: Periode): TiltakspengerVedtak {
@@ -41,7 +42,7 @@ data class TiltakspengerVedtak(
     }
 
     fun getSatser(log: KLogger, idag: LocalDate = LocalDate.now()): Satsdag? {
-        if (rettighet == Rettighet.STANS) {
+        if (rettighet == Rettighet.STANS || rettighet == Rettighet.AVSLAG) {
             return null
         }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
@@ -24,6 +24,7 @@ data class TiltakspengerVedtak(
     val mottattTidspunkt: LocalDateTime,
     override val opprettet: LocalDateTime,
     val barnetillegg: Barnetillegg?,
+    val valgteHjemlerHarIkkeRettighet: List<ValgtHjemmelHarIkkeRettighet>?,
 ) : Periodiserbar {
     val kilde = Kilde.TPSAK
 
@@ -32,6 +33,18 @@ data class TiltakspengerVedtak(
         TILTAKSPENGER_OG_BARNETILLEGG,
         STANS,
         AVSLAG,
+    }
+
+    enum class ValgtHjemmelHarIkkeRettighet {
+        DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK,
+        ALDER,
+        LIVSOPPHOLDSYTELSER,
+        KVALIFISERINGSPROGRAMMET,
+        INTRODUKSJONSPROGRAMMET,
+        LONN_FRA_TILTAKSARRANGOR,
+        LONN_FRA_ANDRE,
+        INSTITUSJONSOPPHOLD,
+        FREMMET_FOR_SENT,
     }
 
     fun oppdaterPeriode(nyPeriode: Periode): TiltakspengerVedtak {

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
@@ -30,8 +30,7 @@ data class TiltakspengerVedtak(
     enum class Rettighet {
         TILTAKSPENGER,
         TILTAKSPENGER_OG_BARNETILLEGG,
-        INGENTING,
-        // TODO post-mvp jah: Legg til støtte for avslag når vi får det i saksbehandling-api
+        STANS,
     }
 
     fun oppdaterPeriode(nyPeriode: Periode): TiltakspengerVedtak {
@@ -42,7 +41,7 @@ data class TiltakspengerVedtak(
     }
 
     fun getSatser(log: KLogger, idag: LocalDate = LocalDate.now()): Satsdag? {
-        if (rettighet == Rettighet.INGENTING) {
+        if (rettighet == Rettighet.STANS) {
             return null
         }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtak.kt
@@ -16,7 +16,6 @@ import java.time.LocalDateTime
 data class TiltakspengerVedtak(
     override val periode: Periode,
     val rettighet: Rettighet,
-    val antallDagerPerMeldeperiode: Int,
     val vedtakId: String,
     val sakId: String,
     val saksnummer: String,

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/db/VedtakRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/db/VedtakRepo.kt
@@ -34,7 +34,6 @@ class VedtakRepo(
                       fnr,
                       fra_og_med,
                       til_og_med,
-                      antall_dager_per_meldeperiode,
                       rettighet,
                       kilde,
                       opprettet_tidspunkt,
@@ -48,7 +47,6 @@ class VedtakRepo(
                       :fnr,
                       :fra_og_med,
                       :til_og_med,
-                      :antall_dager_per_meldeperiode,
                       :rettighet,
                       :kilde,
                       :opprettet_tidspunkt,
@@ -64,7 +62,6 @@ class VedtakRepo(
                         "fnr" to vedtak.fnr.verdi,
                         "fra_og_med" to vedtak.periode.fraOgMed,
                         "til_og_med" to vedtak.periode.tilOgMed,
-                        "antall_dager_per_meldeperiode" to vedtak.antallDagerPerMeldeperiode,
                         "rettighet" to vedtak.rettighet.name,
                         "kilde" to vedtak.kilde.navn,
                         "opprettet_tidspunkt" to vedtak.opprettet,
@@ -185,12 +182,11 @@ class VedtakRepo(
             row.localDate("fra_og_med"),
             row.localDate("til_og_med"),
         ),
-        antallDagerPerMeldeperiode = row.int("antall_dager_per_meldeperiode"),
-        // TODO post-mvp jah: Lag egen db-mapping her.
         rettighet = TiltakspengerVedtak.Rettighet.valueOf(row.string("rettighet")),
         mottattTidspunkt = row.localDateTime("mottatt_tidspunkt"),
         opprettet = row.localDateTime("opprettet_tidspunkt"),
         barnetillegg = row.stringOrNull("barnetillegg")?.let { objectMapper.readValue<Barnetillegg>(it) },
-        valgteHjemlerHarIkkeRettighet = row.stringOrNull("valgte_hjemler_har_ikke_rettighet")?.let { objectMapper.readValue<List<TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet>>(it) },
+        valgteHjemlerHarIkkeRettighet = row.stringOrNull("valgte_hjemler_har_ikke_rettighet")
+            ?.let { objectMapper.readValue<List<TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet>>(it) },
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/db/VedtakRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/db/VedtakRepo.kt
@@ -39,7 +39,8 @@ class VedtakRepo(
                       kilde,
                       opprettet_tidspunkt,
                       mottatt_tidspunkt,
-                      barnetillegg
+                      barnetillegg,
+                      valgte_hjemler_har_ikke_rettighet
                     ) values (
                       :vedtak_id,
                       :sak_id,
@@ -52,7 +53,8 @@ class VedtakRepo(
                       :kilde,
                       :opprettet_tidspunkt,
                       :mottatt_tidspunkt,
-                      :barnetillegg
+                      :barnetillegg,
+                      :valgte_hjemler_har_ikke_rettighet
                     )
                     """.trimIndent(),
                     mapOf(
@@ -68,6 +70,7 @@ class VedtakRepo(
                         "opprettet_tidspunkt" to vedtak.opprettet,
                         "mottatt_tidspunkt" to vedtak.mottattTidspunkt,
                         "barnetillegg" to toPGObject(vedtak.barnetillegg),
+                        "valgte_hjemler_har_ikke_rettighet" to toPGObject(vedtak.valgteHjemlerHarIkkeRettighet),
                     ),
                 ).asUpdate,
             )
@@ -188,5 +191,6 @@ class VedtakRepo(
         mottattTidspunkt = row.localDateTime("mottatt_tidspunkt"),
         opprettet = row.localDateTime("opprettet_tidspunkt"),
         barnetillegg = row.stringOrNull("barnetillegg")?.let { objectMapper.readValue<Barnetillegg>(it) },
+        valgteHjemlerHarIkkeRettighet = row.stringOrNull("valgte_hjemler_har_ikke_rettighet")?.let { objectMapper.readValue<List<TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet>>(it) },
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
@@ -98,7 +98,7 @@ private data class NyttVedktakJson(
             rettighet = when (this.rettighet) {
                 "TILTAKSPENGER" -> TiltakspengerVedtak.Rettighet.TILTAKSPENGER
                 "TILTAKSPENGER_OG_BARNETILLEGG" -> TiltakspengerVedtak.Rettighet.TILTAKSPENGER_OG_BARNETILLEGG
-                "INGENTING" -> TiltakspengerVedtak.Rettighet.INGENTING
+                "INGENTING" -> TiltakspengerVedtak.Rettighet.STANS
                 else -> return ErrorResponse(
                     json = ErrorJson(
                         melding = "Ukjent rettighet: '${this.rettighet}'. Lovlige verdier: 'TILTAKSPENGER'",

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
@@ -91,6 +91,7 @@ private data class NyttVedktakJson(
     val fnr: String,
     val opprettet: String,
     val barnetillegg: Barnetillegg?,
+    val valgteHjemlerHarIkkeRettighet: List<String>?,
 ) {
     fun toDomain(clock: Clock): Either<ErrorResponse, TiltakspengerVedtak> {
         return TiltakspengerVedtak(
@@ -101,10 +102,11 @@ private data class NyttVedktakJson(
                 "INGENTING",
                 "STANS",
                 -> TiltakspengerVedtak.Rettighet.STANS
+
                 "AVSLAG" -> TiltakspengerVedtak.Rettighet.AVSLAG
                 else -> return ErrorResponse(
                     json = ErrorJson(
-                        melding = "Ukjent rettighet: '${this.rettighet}'. Lovlige verdier: 'TILTAKSPENGER'",
+                        melding = "Ukjent rettighet: '${this.rettighet}'.",
                         kode = "ukjent_rettighet",
                     ),
                     httpStatus = HttpStatusCode.BadRequest,
@@ -118,6 +120,20 @@ private data class NyttVedktakJson(
             opprettet = LocalDateTime.parse(this.opprettet),
             barnetillegg = this.barnetillegg,
             mottattTidspunkt = nå(clock),
+            valgteHjemlerHarIkkeRettighet = valgteHjemlerHarIkkeRettighet?.map { toValgtHjemmelHarIkkeRettighet(it) },
         ).right()
+    }
+
+    private fun toValgtHjemmelHarIkkeRettighet(valgtHjemmel: String) = when (valgtHjemmel) {
+        "DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK
+        "ALDER" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.ALDER
+        "LIVSOPPHOLDSYTELSER" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.LIVSOPPHOLDSYTELSER
+        "KVALIFISERINGSPROGRAMMET" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.KVALIFISERINGSPROGRAMMET
+        "INTRODUKSJONSPROGRAMMET" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.INTRODUKSJONSPROGRAMMET
+        "LONN_FRA_TILTAKSARRANGOR" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.LONN_FRA_TILTAKSARRANGOR
+        "LONN_FRA_ANDRE" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.LONN_FRA_ANDRE
+        "INSTITUSJONSOPPHOLD" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.INSTITUSJONSOPPHOLD
+        "FREMMET_FOR_SENT" -> TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.FREMMET_FOR_SENT
+        else -> throw IllegalArgumentException("Ukjent valgt hjemmel for stans/avslag: $valgtHjemmel")
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
@@ -98,7 +98,10 @@ private data class NyttVedktakJson(
             rettighet = when (this.rettighet) {
                 "TILTAKSPENGER" -> TiltakspengerVedtak.Rettighet.TILTAKSPENGER
                 "TILTAKSPENGER_OG_BARNETILLEGG" -> TiltakspengerVedtak.Rettighet.TILTAKSPENGER_OG_BARNETILLEGG
-                "INGENTING" -> TiltakspengerVedtak.Rettighet.STANS
+                "INGENTING",
+                "STANS",
+                -> TiltakspengerVedtak.Rettighet.STANS
+                "AVSLAG" -> TiltakspengerVedtak.Rettighet.AVSLAG
                 else -> return ErrorResponse(
                     json = ErrorJson(
                         melding = "Ukjent rettighet: '${this.rettighet}'. Lovlige verdier: 'TILTAKSPENGER'",

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/http/server/MottaNyttVedtakRoute.kt
@@ -76,15 +76,10 @@ internal fun Route.mottaNyttVedtakRoute(
     }
 }
 
-/**
- * @param antallDagerPerMeldeperiode antall dager en bruker skal melde seg for hver meldeperiode.
- * @param antallDagerPerMeldeperiode antall dager en meldeperiode varer, inkl. helg. Alltid 2 uker (14 dager) i MVP. Kan tenkes at den blir 1 uke i spesialtilfeller.
- */
 private data class NyttVedktakJson(
     val vedtakId: String,
     val fom: LocalDate,
     val tom: LocalDate,
-    val antallDagerPerMeldeperiode: Int,
     val rettighet: String,
     val sakId: String,
     val saksnummer: String,
@@ -112,7 +107,6 @@ private data class NyttVedktakJson(
                     httpStatus = HttpStatusCode.BadRequest,
                 ).left()
             },
-            antallDagerPerMeldeperiode = this.antallDagerPerMeldeperiode,
             vedtakId = this.vedtakId,
             sakId = this.sakId,
             saksnummer = this.saksnummer,

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDTO.kt
@@ -65,7 +65,11 @@ fun TiltakspengerVedtak.toVedtakDTO(log: KLogger): VedtakDTO {
     val satser = this.getSatser(log)
     return VedtakDTO(
         vedtakId = vedtakId,
-        rettighet = VedtakDTO.RettighetDTO.valueOf(rettighet.name),
+        rettighet = when (rettighet) {
+            TiltakspengerVedtak.Rettighet.STANS -> VedtakDTO.RettighetDTO.INGENTING
+            TiltakspengerVedtak.Rettighet.TILTAKSPENGER -> VedtakDTO.RettighetDTO.TILTAKSPENGER
+            TiltakspengerVedtak.Rettighet.TILTAKSPENGER_OG_BARNETILLEGG -> VedtakDTO.RettighetDTO.TILTAKSPENGER_OG_BARNETILLEGG
+        },
         periode = VedtakDTO.PeriodeDTO(
             fraOgMed = periode.fraOgMed,
             tilOgMed = periode.tilOgMed,

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDTO.kt
@@ -69,6 +69,7 @@ fun TiltakspengerVedtak.toVedtakDTO(log: KLogger): VedtakDTO {
             TiltakspengerVedtak.Rettighet.STANS -> VedtakDTO.RettighetDTO.INGENTING
             TiltakspengerVedtak.Rettighet.TILTAKSPENGER -> VedtakDTO.RettighetDTO.TILTAKSPENGER
             TiltakspengerVedtak.Rettighet.TILTAKSPENGER_OG_BARNETILLEGG -> VedtakDTO.RettighetDTO.TILTAKSPENGER_OG_BARNETILLEGG
+            TiltakspengerVedtak.Rettighet.AVSLAG -> throw IllegalStateException("Dette apiet skal ikke returnere avslag")
         },
         periode = VedtakDTO.PeriodeDTO(
             fraOgMed = periode.fraOgMed,

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerResponse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerResponse.kt
@@ -38,7 +38,7 @@ internal fun TiltakspengerVedtak.toVedtakDetaljerResponse(log: KLogger): VedtakD
         rettighet = when (this.rettighet) {
             TiltakspengerVedtak.Rettighet.TILTAKSPENGER -> RettighetResponseJson.TILTAKSPENGER
             TiltakspengerVedtak.Rettighet.TILTAKSPENGER_OG_BARNETILLEGG -> RettighetResponseJson.TILTAKSPENGER_OG_BARNETILLEGG
-            TiltakspengerVedtak.Rettighet.INGENTING -> RettighetResponseJson.INGENTING
+            TiltakspengerVedtak.Rettighet.STANS -> RettighetResponseJson.INGENTING
         },
         vedtakId = this.vedtakId,
         sakId = this.sakId,

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerResponse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerResponse.kt
@@ -39,6 +39,7 @@ internal fun TiltakspengerVedtak.toVedtakDetaljerResponse(log: KLogger): VedtakD
             TiltakspengerVedtak.Rettighet.TILTAKSPENGER -> RettighetResponseJson.TILTAKSPENGER
             TiltakspengerVedtak.Rettighet.TILTAKSPENGER_OG_BARNETILLEGG -> RettighetResponseJson.TILTAKSPENGER_OG_BARNETILLEGG
             TiltakspengerVedtak.Rettighet.STANS -> RettighetResponseJson.INGENTING
+            TiltakspengerVedtak.Rettighet.AVSLAG -> throw IllegalStateException("Dette apiet skal ikke returnere avslag")
         },
         vedtakId = this.vedtakId,
         sakId = this.sakId,

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakService.kt
@@ -28,6 +28,7 @@ class VedtakService(
         periode: Periode,
     ): List<TiltakspengerVedtak> {
         val toTidslinje = vedtakRepo.hentForFnrOgPeriode(fnr, periode, Kilde.TPSAK)
+            .filter { it.rettighet != TiltakspengerVedtak.Rettighet.AVSLAG }
             .toTidslinje()
         return toTidslinje
             .filter { it.verdi.rettighet != TiltakspengerVedtak.Rettighet.STANS }
@@ -40,6 +41,7 @@ class VedtakService(
         periode: Periode,
     ): List<VedtakDTO> {
         val vedtakFraTpsak = vedtakRepo.hentForFnrOgPeriode(fnr, periode, Kilde.TPSAK)
+            .filter { it.rettighet != TiltakspengerVedtak.Rettighet.AVSLAG }
             .map { it.toVedtakDTO(logger) }
         val vedtakFraArena = arenaClient.hentVedtak(fnr, periode)
             .filter { it.rettighet != Rettighet.BARNETILLEGG }

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakService.kt
@@ -2,7 +2,6 @@ package no.nav.tiltakspenger.datadeling.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.datadeling.client.arena.ArenaClient
-import no.nav.tiltakspenger.datadeling.client.arena.log
 import no.nav.tiltakspenger.datadeling.domene.Kilde
 import no.nav.tiltakspenger.datadeling.domene.Rettighet
 import no.nav.tiltakspenger.datadeling.domene.TiltakspengerVedtak
@@ -31,7 +30,7 @@ class VedtakService(
         val toTidslinje = vedtakRepo.hentForFnrOgPeriode(fnr, periode, Kilde.TPSAK)
             .toTidslinje()
         return toTidslinje
-            .filter { it.verdi.rettighet != TiltakspengerVedtak.Rettighet.INGENTING }
+            .filter { it.verdi.rettighet != TiltakspengerVedtak.Rettighet.STANS }
             .map { it.verdi.oppdaterPeriode(it.periode) }
             .verdier
     }

--- a/src/main/resources/db/migration/V10__rammevedtak_fjern_antall_dager_per_meldeperiode.sql
+++ b/src/main/resources/db/migration/V10__rammevedtak_fjern_antall_dager_per_meldeperiode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rammevedtak
+DROP COLUMN antall_dager_per_meldeperiode;

--- a/src/main/resources/db/migration/V8__rammevedtak_migrer_rettighet.sql
+++ b/src/main/resources/db/migration/V8__rammevedtak_migrer_rettighet.sql
@@ -1,0 +1,3 @@
+UPDATE rammevedtak
+SET rettighet = 'STANS'
+WHERE rettighet = 'INGENTING';

--- a/src/main/resources/db/migration/V9__rammevedtak_valgte_hjemler_har_ikke_rettighet.sql
+++ b/src/main/resources/db/migration/V9__rammevedtak_valgte_hjemler_har_ikke_rettighet.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rammevedtak ADD COLUMN IF NOT EXISTS valgte_hjemler_har_ikke_rettighet jsonb;

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtakstidslinjeKtTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/domene/TiltakspengerVedtakstidslinjeKtTest.kt
@@ -24,7 +24,7 @@ class TiltakspengerVedtakstidslinjeKtTest {
             fom = 15.januar(2024),
             tom = 31.januar(2024),
             opprettetTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.001"),
-            rettighet = TiltakspengerVedtak.Rettighet.INGENTING,
+            rettighet = TiltakspengerVedtak.Rettighet.STANS,
         )
         listOf(v1, v2).toTidslinje() shouldBe Periodisering(
             PeriodeMedVerdi(v1, 1 til 14.januar(2024)),

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/felles/VedtakMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/felles/VedtakMother.kt
@@ -21,6 +21,7 @@ object VedtakMother {
         mottattTidspunkt: LocalDateTime = LocalDateTime.parse("2021-01-01T00:00:00.000"),
         opprettetTidspunkt: LocalDateTime = LocalDateTime.parse("2021-01-01T00:00:00.000"),
         barnetillegg: Barnetillegg? = null,
+        valgteHjemlerHarIkkeRettighet: List<TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet>? = null,
     ) = TiltakspengerVedtak(
         periode = Periode(fom, tom),
         antallDagerPerMeldeperiode = antallDagerPerMeldeperiode,
@@ -32,5 +33,6 @@ object VedtakMother {
         mottattTidspunkt = mottattTidspunkt,
         opprettet = opprettetTidspunkt,
         barnetillegg = barnetillegg,
+        valgteHjemlerHarIkkeRettighet = valgteHjemlerHarIkkeRettighet,
     )
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/felles/VedtakMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/felles/VedtakMother.kt
@@ -12,7 +12,6 @@ object VedtakMother {
     fun tiltakspengerVedtak(
         fom: LocalDate = LocalDate.of(2024, 1, 1),
         tom: LocalDate = LocalDate.of(2024, 1, 31),
-        antallDagerPerMeldeperiode: Int = 10,
         rettighet: TiltakspengerVedtak.Rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
         vedtakId: String = UUID.randomUUID().toString(),
         sakId: String = "sakId",
@@ -24,7 +23,6 @@ object VedtakMother {
         valgteHjemlerHarIkkeRettighet: List<TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet>? = null,
     ) = TiltakspengerVedtak(
         periode = Periode(fom, tom),
-        antallDagerPerMeldeperiode = antallDagerPerMeldeperiode,
         rettighet = rettighet,
         vedtakId = vedtakId,
         sakId = sakId,

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/db/VedtakRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/motta/infra/db/VedtakRepoTest.kt
@@ -69,4 +69,21 @@ class VedtakRepoTest {
             }
         }
     }
+
+    @Test
+    fun `kan lagre og hente avslagsvedtak`() {
+        withMigratedDb { testDataHelper ->
+            val repo = testDataHelper.vedtakRepo
+
+            val vedtak = VedtakMother.tiltakspengerVedtak(
+                rettighet = TiltakspengerVedtak.Rettighet.AVSLAG,
+                valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.KVALIFISERINGSPROGRAMMET),
+            )
+            repo.lagre(vedtak)
+
+            testDataHelper.sessionFactory.withSession { session ->
+                repo.hentForVedtakIdOgKilde(vedtak.vedtakId, vedtak.kilde, session) shouldBe vedtak
+            }
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerRoutesTest.kt
@@ -70,6 +70,7 @@ internal class VedtakDetaljerRoutesTest {
                         mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                         opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                         barnetillegg = null,
+                        valgteHjemlerHarIkkeRettighet = null,
                     ),
                 )
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakDetaljerRoutesTest.kt
@@ -66,7 +66,6 @@ internal class VedtakDetaljerRoutesTest {
                         sakId = "9876543210",
                         saksnummer = "12345678910",
                         fnr = Fnr.random(),
-                        antallDagerPerMeldeperiode = 10,
                         mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                         opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                         barnetillegg = null,

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentPerioderTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentPerioderTest.kt
@@ -348,7 +348,7 @@ class VedtakRoutesHentPerioderTest {
                 val tpVedtakStanset = VedtakMother.tiltakspengerVedtak(
                     vedtakId = "vedtakId2",
                     fnr = Fnr.fromString("12345678910"),
-                    rettighet = TiltakspengerVedtak.Rettighet.INGENTING,
+                    rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     fom = LocalDate.of(2024, 2, 1),
                     tom = LocalDate.of(2024, 3, 1),
                 )

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentTest.kt
@@ -60,6 +60,7 @@ class VedtakRoutesHentTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = Barnetillegg(perioder = listOf(BarnetilleggPeriode(antallBarn = 1, periode = Periode(periode.fraOgMed, periode.tilOgMed)))),
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
             )
             val systembruker = Systembruker(
@@ -154,6 +155,7 @@ class VedtakRoutesHentTest {
                     mottattTidspunkt = LocalDateTime.parse("2024-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2024-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
                 TiltakspengerVedtak(
                     periode = Periode(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 12, 31)),
@@ -166,6 +168,7 @@ class VedtakRoutesHentTest {
                     mottattTidspunkt = LocalDateTime.parse("2024-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2024-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK),
                 ),
             )
             val systembruker = Systembruker(
@@ -268,6 +271,7 @@ class VedtakRoutesHentTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
             )
             val systembruker = Systembruker(

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentTest.kt
@@ -158,7 +158,7 @@ class VedtakRoutesHentTest {
                 TiltakspengerVedtak(
                     periode = Periode(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 12, 31)),
                     antallDagerPerMeldeperiode = 10,
-                    rettighet = TiltakspengerVedtak.Rettighet.INGENTING,
+                    rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "",
                     sakId = "",
                     saksnummer = saksnummer,

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/routes/vedtak/VedtakRoutesHentTest.kt
@@ -51,7 +51,6 @@ class VedtakRoutesHentTest {
             coEvery { vedtakService.hentTpVedtak(any(), any()) } returns listOf(
                 TiltakspengerVedtak(
                     periode = periode,
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "",
                     sakId = "",
@@ -146,7 +145,6 @@ class VedtakRoutesHentTest {
             coEvery { vedtakService.hentTpVedtak(any(), any()) } returns listOf(
                 TiltakspengerVedtak(
                     periode = periode,
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "",
                     sakId = "",
@@ -159,7 +157,6 @@ class VedtakRoutesHentTest {
                 ),
                 TiltakspengerVedtak(
                     periode = Periode(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 12, 31)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "",
                     sakId = "",
@@ -262,7 +259,6 @@ class VedtakRoutesHentTest {
             coEvery { vedtakService.hentTpVedtak(any(), any()) } returns listOf(
                 TiltakspengerVedtak(
                     periode = Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2024, 12, 31)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "",
                     sakId = "",

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakServiceTest.kt
@@ -43,6 +43,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
             )
             coEvery { vedtakRepo.hentForFnrOgPeriode(fnr, any(), Kilde.TPSAK) } returns expectedVedtakFraVedtak
@@ -66,6 +67,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
                 TiltakspengerVedtak(
                     periode = (1 til 31.mars(2022)),
@@ -78,6 +80,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-03-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-03-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
             )
             coEvery { vedtakRepo.hentForFnrOgPeriode(fnr, any(), Kilde.TPSAK) } returns expectedVedtakFraVedtak
@@ -101,6 +104,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
                 TiltakspengerVedtak(
                     periode = (1.februar(2022) til 31.mars(2022)),
@@ -113,6 +117,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2022-01-02T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2022-01-02T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK),
                 ),
             )
             coEvery { vedtakRepo.hentForFnrOgPeriode(fnr, any(), Kilde.TPSAK) } returns vedtaksliste
@@ -129,6 +134,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
             )
         }
@@ -149,6 +155,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.mars(2022)),
@@ -161,6 +168,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2022-01-02T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2022-01-02T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK),
                 ),
             )
             coEvery { vedtakRepo.hentForFnrOgPeriode(fnr, any(), Kilde.TPSAK) } returns vedtaksliste
@@ -184,6 +192,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
                 TiltakspengerVedtak(
                     periode = (1.februar(2022) til 28.februar(2022)),
@@ -196,6 +205,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2022-01-02T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2022-01-02T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK),
                 ),
             )
             coEvery { vedtakRepo.hentForFnrOgPeriode(fnr, any(), Kilde.TPSAK) } returns vedtaksliste
@@ -212,6 +222,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
                 TiltakspengerVedtak(
                     periode = 1.mars(2022) til 31.mars(2022),
@@ -224,6 +235,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = null,
                 ),
             )
         }
@@ -244,6 +256,7 @@ class VedtakServiceTest {
                     mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                     barnetillegg = null,
+                    valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.FREMMET_FOR_SENT),
                 ),
             )
             coEvery { vedtakRepo.hentForFnrOgPeriode(fnr, any(), Kilde.TPSAK) } returns expectedVedtakFraVedtak
@@ -266,6 +279,7 @@ class VedtakServiceTest {
                 mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                 opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                 barnetillegg = null,
+                valgteHjemlerHarIkkeRettighet = null,
             )
             val avslag = TiltakspengerVedtak(
                 periode = 10 til 31.januar(2022),
@@ -278,6 +292,7 @@ class VedtakServiceTest {
                 mottattTidspunkt = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                 opprettet = LocalDateTime.parse("2021-01-01T00:00:00.000"),
                 barnetillegg = null,
+                valgteHjemlerHarIkkeRettighet = listOf(TiltakspengerVedtak.ValgtHjemmelHarIkkeRettighet.LIVSOPPHOLDSYTELSER),
             )
             val expectedVedtakFraVedtak = listOf(
                 innvilgetVedtak,

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakServiceTest.kt
@@ -105,7 +105,7 @@ class VedtakServiceTest {
                 TiltakspengerVedtak(
                     periode = (1.februar(2022) til 31.mars(2022)),
                     antallDagerPerMeldeperiode = 10,
-                    rettighet = TiltakspengerVedtak.Rettighet.INGENTING,
+                    rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "v2",
                     sakId = "s1",
                     saksnummer = "sa1",
@@ -153,7 +153,7 @@ class VedtakServiceTest {
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.mars(2022)),
                     antallDagerPerMeldeperiode = 10,
-                    rettighet = TiltakspengerVedtak.Rettighet.INGENTING,
+                    rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "v2",
                     sakId = "s1",
                     saksnummer = "sa1",
@@ -188,7 +188,7 @@ class VedtakServiceTest {
                 TiltakspengerVedtak(
                     periode = (1.februar(2022) til 28.februar(2022)),
                     antallDagerPerMeldeperiode = 10,
-                    rettighet = TiltakspengerVedtak.Rettighet.INGENTING,
+                    rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "v2",
                     sakId = "s1",
                     saksnummer = "sa1",

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/service/VedtakServiceTest.kt
@@ -34,7 +34,6 @@ class VedtakServiceTest {
             val expectedVedtakFraVedtak = listOf(
                 TiltakspengerVedtak(
                     periode = 1 til 31.januar(2022),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "987654",
                     sakId = "67676767",
@@ -58,7 +57,6 @@ class VedtakServiceTest {
             val expectedVedtakFraVedtak = listOf(
                 TiltakspengerVedtak(
                     periode = (1 til 31.januar(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "987654",
                     sakId = "67676767",
@@ -71,7 +69,6 @@ class VedtakServiceTest {
                 ),
                 TiltakspengerVedtak(
                     periode = (1 til 31.mars(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "987654",
                     sakId = "67676767",
@@ -95,7 +92,6 @@ class VedtakServiceTest {
             val vedtaksliste = listOf(
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.mars(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "v1",
                     sakId = "s1",
@@ -108,7 +104,6 @@ class VedtakServiceTest {
                 ),
                 TiltakspengerVedtak(
                     periode = (1.februar(2022) til 31.mars(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "v2",
                     sakId = "s1",
@@ -125,7 +120,6 @@ class VedtakServiceTest {
             result shouldBe listOf(
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.januar(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "v1",
                     sakId = "s1",
@@ -146,7 +140,6 @@ class VedtakServiceTest {
             val vedtaksliste = listOf(
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.mars(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "v1",
                     sakId = "s1",
@@ -159,7 +152,6 @@ class VedtakServiceTest {
                 ),
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.mars(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "v2",
                     sakId = "s1",
@@ -183,7 +175,6 @@ class VedtakServiceTest {
             val vedtaksliste = listOf(
                 TiltakspengerVedtak(
                     periode = (1.januar(2022) til 31.mars(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "v1",
                     sakId = "s1",
@@ -196,7 +187,6 @@ class VedtakServiceTest {
                 ),
                 TiltakspengerVedtak(
                     periode = (1.februar(2022) til 28.februar(2022)),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.STANS,
                     vedtakId = "v2",
                     sakId = "s1",
@@ -213,7 +203,6 @@ class VedtakServiceTest {
             result shouldBe listOf(
                 TiltakspengerVedtak(
                     periode = 1.januar(2022) til 31.januar(2022),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "v1",
                     sakId = "s1",
@@ -226,7 +215,6 @@ class VedtakServiceTest {
                 ),
                 TiltakspengerVedtak(
                     periode = 1.mars(2022) til 31.mars(2022),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                     vedtakId = "v1",
                     sakId = "s1",
@@ -247,7 +235,6 @@ class VedtakServiceTest {
             val expectedVedtakFraVedtak = listOf(
                 TiltakspengerVedtak(
                     periode = 1 til 31.januar(2022),
-                    antallDagerPerMeldeperiode = 10,
                     rettighet = TiltakspengerVedtak.Rettighet.AVSLAG,
                     vedtakId = "987654",
                     sakId = "67676767",
@@ -270,7 +257,6 @@ class VedtakServiceTest {
         runBlocking {
             val innvilgetVedtak = TiltakspengerVedtak(
                 periode = 1 til 31.januar(2022),
-                antallDagerPerMeldeperiode = 10,
                 rettighet = TiltakspengerVedtak.Rettighet.TILTAKSPENGER,
                 vedtakId = "987654",
                 sakId = "67676767",
@@ -283,7 +269,6 @@ class VedtakServiceTest {
             )
             val avslag = TiltakspengerVedtak(
                 periode = 10 til 31.januar(2022),
-                antallDagerPerMeldeperiode = 10,
                 rettighet = TiltakspengerVedtak.Rettighet.AVSLAG,
                 vedtakId = "987654123",
                 sakId = "67676767",


### PR DESCRIPTION
Tilpasser den interne modellen slik at den passer bedre med vår saksbehandlingsmodell. Legger også til rette for å dele avslag og stans/avslagsgrunner. 

Ingen apier som brukes av konsumentene våre er endret, og tilpasningene i apiet for å lagre vedtak er bakoverkompatible. Siden det er både databaseendringer og kodeendringer i samme pr vil konsumentene kunne oppleve feil akkurat ved deploy, men det bør være til å leve med. 

https://trello.com/c/A9xGZY5O/1412-nks-salesforce-trenger-data-om-tiltakspengevedtak-og-meldekort