### PR TITLE
1683 mottar og lagrer meldeperioder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation("com.github.navikt.tiltakspenger-libs:kafka:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:texas:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:satser:$felleslibVersion")
+    implementation("com.github.navikt.tiltakspenger-libs:meldekort:${felleslibVersion}")
 
     // Ktor server
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersjon")

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/Application.kt
@@ -27,6 +27,7 @@ import no.nav.tiltakspenger.datadeling.behandling.motta.MottaNyBehandlingService
 import no.nav.tiltakspenger.datadeling.client.arena.ArenaClient
 import no.nav.tiltakspenger.datadeling.identhendelse.IdenthendelseConsumer
 import no.nav.tiltakspenger.datadeling.identhendelse.IdenthendelseService
+import no.nav.tiltakspenger.datadeling.meldekort.db.MeldeperiodeRepo
 import no.nav.tiltakspenger.datadeling.routes.healthRoutes
 import no.nav.tiltakspenger.datadeling.routes.mottaRoutes
 import no.nav.tiltakspenger.datadeling.routes.swaggerRoute
@@ -82,6 +83,7 @@ fun Application.module(log: KLogger, clock: Clock) {
 
     val behandlingRepo = BehandlingRepo(sessionFactory)
     val vedtakRepo = VedtakRepo(sessionFactory)
+    val meldeperiodeRepo = MeldeperiodeRepo(sessionFactory)
 
     val vedtakService = VedtakService(vedtakRepo, arenaClient)
     val behandlingService = BehandlingService(behandlingRepo)
@@ -89,7 +91,7 @@ fun Application.module(log: KLogger, clock: Clock) {
     val mottaNyttVedtakService = MottaNyttVedtakService(vedtakRepo)
     val mottaNyBehandlingService = MottaNyBehandlingService(behandlingRepo)
 
-    val identhendelseService = IdenthendelseService(behandlingRepo, vedtakRepo)
+    val identhendelseService = IdenthendelseService(behandlingRepo, vedtakRepo, meldeperiodeRepo)
     val identhendelseConsumer = IdenthendelseConsumer(
         identhendelseService = identhendelseService,
         topic = Configuration.identhendelseTopic,
@@ -107,7 +109,7 @@ fun Application.module(log: KLogger, clock: Clock) {
         authenticate(IdentityProvider.AZUREAD.value) {
             vedtakRoutes(vedtakService)
             behandlingRoutes(behandlingService)
-            mottaRoutes(mottaNyttVedtakService, mottaNyBehandlingService, clock)
+            mottaRoutes(mottaNyttVedtakService, mottaNyBehandlingService, clock, meldeperiodeRepo)
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/identhendelse/IdenthendelseService.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.datadeling.identhendelse
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.datadeling.behandling.db.BehandlingRepo
+import no.nav.tiltakspenger.datadeling.meldekort.db.MeldeperiodeRepo
 import no.nav.tiltakspenger.datadeling.vedtak.db.VedtakRepo
 import no.nav.tiltakspenger.libs.common.Fnr
 import java.util.UUID
@@ -9,6 +10,7 @@ import java.util.UUID
 class IdenthendelseService(
     private val behandlingRepo: BehandlingRepo,
     private val vedtakRepo: VedtakRepo,
+    private val meldeperiodeRepo: MeldeperiodeRepo,
 ) {
     private val log = KotlinLogging.logger { }
 
@@ -17,6 +19,7 @@ class IdenthendelseService(
         val nyttFnr = Fnr.fromString(identhendelseDto.nyttFnr)
         behandlingRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
         vedtakRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
+        meldeperiodeRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
         log.info { "Oppdatert fnr for identhendelse med id $id" }
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/meldekort/db/MeldeperiodeRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/meldekort/db/MeldeperiodeRepo.kt
@@ -1,0 +1,159 @@
+package no.nav.tiltakspenger.datadeling.meldekort.db
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotliquery.Row
+import kotliquery.Session
+import kotliquery.queryOf
+import no.nav.tiltakspenger.datadeling.application.db.toPGObject
+import no.nav.tiltakspenger.datadeling.meldekort.domene.Meldeperiode
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.json.objectMapper
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.sqlQuery
+import java.time.LocalDate
+
+class MeldeperiodeRepo(
+    private val sessionFactory: PostgresSessionFactory,
+) {
+    val log = KotlinLogging.logger { }
+
+    fun lagre(meldeperioder: List<Meldeperiode>) {
+        return sessionFactory.withTransaction { session ->
+            meldeperioder.filterNot { it.minstEnDagGirRettIPerioden }
+                .forEach {
+                    log.info { "Sletter meldeperiode der ingen dager gir rett: ${it.id}" }
+                    slett(it.id, session)
+                }
+            meldeperioder.filter { it.minstEnDagGirRettIPerioden }
+                .forEach {
+                    lagre(it, session)
+                    log.info { "Lagret meldeperiode med id ${it.id}" }
+                }
+        }
+    }
+
+    private fun slett(
+        id: MeldeperiodeId,
+        session: Session,
+    ): Int {
+        return session.run(
+            queryOf(
+                "delete from meldeperiode where id = :id",
+                mapOf(
+                    "id" to id.toString(),
+                ),
+            ).asUpdate,
+        )
+    }
+
+    private fun lagre(
+        meldeperiode: Meldeperiode,
+        session: Session,
+    ) {
+        session.run(
+            sqlQuery(
+                """
+                    insert into meldeperiode (
+                        id,
+                        kjede_id,
+                        sak_id,
+                        saksnummer,
+                        fnr,
+                        opprettet,
+                        fra_og_med,
+                        til_og_med,
+                        maks_antall_dager_for_periode,
+                        gir_rett
+                    ) values (
+                        :id,
+                        :kjede_id,
+                        :sak_id,
+                        :saksnummer,
+                        :fnr,
+                        :opprettet,
+                        :fra_og_med,
+                        :til_og_med,
+                        :maks_antall_dager_for_periode,
+                        :gir_rett
+                    )
+                    on conflict (id) do update set
+                        kjede_id = :kjede_id,
+                        sak_id = :sak_id,
+                        saksnummer = :saksnummer,
+                        fnr = :fnr,
+                        opprettet = :opprettet,
+                        fra_og_med = :fra_og_med,
+                        til_og_med = :til_og_med,
+                        maks_antall_dager_for_periode = :maks_antall_dager_for_periode,
+                        gir_rett = :gir_rett
+                """,
+                "id" to meldeperiode.id.toString(),
+                "kjede_id" to meldeperiode.kjedeId,
+                "sak_id" to meldeperiode.sakId.toString(),
+                "saksnummer" to meldeperiode.saksnummer,
+                "fnr" to meldeperiode.fnr.verdi,
+                "opprettet" to meldeperiode.opprettet,
+                "fra_og_med" to meldeperiode.fraOgMed,
+                "til_og_med" to meldeperiode.tilOgMed,
+                "maks_antall_dager_for_periode" to meldeperiode.maksAntallDagerForPeriode,
+                "gir_rett" to toPGObject(meldeperiode.girRett),
+            ).asUpdate,
+        )
+    }
+
+    fun hentForFnrOgPeriode(
+        fnr: Fnr,
+        periode: Periode,
+    ): List<Meldeperiode> {
+        return sessionFactory.withSession { session ->
+            session.run(
+                queryOf(
+                    """
+                    select * from meldeperiode
+                      where fnr = :fnr
+                      and fra_og_med <= :til_og_med
+                      and til_og_med >= :fra_og_med
+                    """.trimIndent(),
+                    mapOf(
+                        "fra_og_med" to periode.fraOgMed,
+                        "til_og_med" to periode.tilOgMed,
+                        "fnr" to fnr.verdi,
+                    ),
+                ).map {
+                    fromRow(it)
+                }.asList,
+            )
+        }
+    }
+
+    fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        sessionFactory.withSession { session ->
+            session.run(
+                queryOf(
+                    """update meldeperiode set fnr = :nytt_fnr where fnr = :gammelt_fnr""",
+                    mapOf(
+                        "nytt_fnr" to nyttFnr.verdi,
+                        "gammelt_fnr" to gammeltFnr.verdi,
+                    ),
+                ).asUpdate,
+            )
+        }
+    }
+
+    private fun fromRow(row: Row): Meldeperiode = Meldeperiode(
+        id = MeldeperiodeId.fromString(row.string("id")),
+        kjedeId = row.string("kjede_id"),
+        fnr = Fnr.fromString(row.string("fnr")),
+        sakId = SakId.fromString(row.string("sak_id")),
+        saksnummer = row.string("saksnummer"),
+        opprettet = row.localDateTime("opprettet"),
+        fraOgMed = row.localDate("fra_og_med"),
+        tilOgMed = row.localDate("til_og_med"),
+        maksAntallDagerForPeriode = row.int("maks_antall_dager_for_periode"),
+        girRett = objectMapper.readValue<Map<LocalDate, Boolean>>(row.string("gir_rett")),
+    )
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/meldekort/domene/Meldeperiode.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/meldekort/domene/Meldeperiode.kt
@@ -1,0 +1,22 @@
+package no.nav.tiltakspenger.datadeling.meldekort.domene
+
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class Meldeperiode(
+    val id: MeldeperiodeId,
+    val kjedeId: String,
+    val fnr: Fnr,
+    val sakId: SakId,
+    val saksnummer: String,
+    val opprettet: LocalDateTime,
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate,
+    val maksAntallDagerForPeriode: Int,
+    val girRett: Map<LocalDate, Boolean>,
+) {
+    val minstEnDagGirRettIPerioden = girRett.any { it.value }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/meldekort/motta/routes/MottaMeldeperioderRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/meldekort/motta/routes/MottaMeldeperioderRoute.kt
@@ -1,0 +1,94 @@
+package no.nav.tiltakspenger.datadeling.meldekort.motta.routes
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.tiltakspenger.datadeling.domene.Systembruker
+import no.nav.tiltakspenger.datadeling.domene.Systembrukerrolle
+import no.nav.tiltakspenger.datadeling.getSystemBrukerMapper
+import no.nav.tiltakspenger.datadeling.meldekort.db.MeldeperiodeRepo
+import no.nav.tiltakspenger.datadeling.meldekort.domene.Meldeperiode
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
+import no.nav.tiltakspenger.libs.ktor.common.respond500InternalServerError
+import no.nav.tiltakspenger.libs.ktor.common.withBody
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
+import no.nav.tiltakspenger.libs.texas.systembruker
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+fun Route.mottaMeldeperioderRoute(
+    meldeperiodeRepo: MeldeperiodeRepo,
+) {
+    val log = KotlinLogging.logger {}
+    post("/meldeperioder") {
+        log.debug { "Mottatt POST kall på /meldeperioder - lagre meldeperioder fra tiltakspenger-saksbehandling-api" }
+        val systembruker = call.systembruker(getSystemBrukerMapper()) as? Systembruker ?: return@post
+        if (!systembruker.roller.kanLagreTiltakspengerHendelser()) {
+            log.warn { "Systembruker ${systembruker.klientnavn} fikk 403 Forbidden mot POST /meldeperioder. Underliggende feil: Mangler rollen ${Systembrukerrolle.LAGRE_TILTAKSPENGER_HENDELSER}" }
+            call.respond403Forbidden(
+                "Mangler rollen ${Systembrukerrolle.LAGRE_TILTAKSPENGER_HENDELSER}. Har rollene: ${systembruker.roller.toList()}",
+                "mangler_rolle",
+            )
+            return@post
+        }
+
+        call.withBody<MeldeperioderDTO> { body ->
+            val meldeperioder = body.toDomain()
+            if (meldeperioder.isEmpty()) {
+                log.info { "Ingen meldeperioder for sakId ${body.sakId} gir rett, lagrer ingenting" }
+                call.respond(HttpStatusCode.OK)
+                return@withBody
+            }
+            try {
+                meldeperiodeRepo.lagre(meldeperioder)
+                call.respond(HttpStatusCode.OK)
+                log.debug { "Systembruker ${systembruker.klientnavn} lagret meldeperioder OK." }
+            } catch (e: Exception) {
+                log.error { "Systembruker ${systembruker.klientnavn} fikk 500 Internal Server Error mot POST /meldeperioder. Underliggende feil: ${e.message}" }
+                call.respond500InternalServerError(
+                    "Meldeperioder kunne ikke lagres siden en ukjent feil oppstod",
+                    "ukjent_feil",
+                )
+                return@withBody
+            }
+        }
+    }
+}
+
+private data class MeldeperioderDTO(
+    val fnr: String,
+    val sakId: String,
+    val saksnummer: String,
+    val meldeperioder: List<MeldeperiodeDTO>,
+) {
+    data class MeldeperiodeDTO(
+        val id: String,
+        val kjedeId: String,
+        val opprettet: LocalDateTime,
+        val fraOgMed: LocalDate,
+        val tilOgMed: LocalDate,
+        val antallDagerForPeriode: Int,
+        val girRett: Map<LocalDate, Boolean>,
+    )
+
+    fun toDomain(): List<Meldeperiode> {
+        return meldeperioder.map {
+            Meldeperiode(
+                id = MeldeperiodeId.fromString(it.id),
+                kjedeId = it.kjedeId,
+                fnr = Fnr.fromString(fnr),
+                sakId = SakId.fromString(sakId),
+                saksnummer = saksnummer,
+                opprettet = it.opprettet,
+                fraOgMed = it.fraOgMed,
+                tilOgMed = it.tilOgMed,
+                maksAntallDagerForPeriode = it.antallDagerForPeriode,
+                girRett = it.girRett,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/MottaRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/routes/MottaRoutes.kt
@@ -3,6 +3,8 @@ package no.nav.tiltakspenger.datadeling.routes
 import io.ktor.server.routing.Route
 import no.nav.tiltakspenger.datadeling.behandling.motta.MottaNyBehandlingService
 import no.nav.tiltakspenger.datadeling.behandling.motta.routes.mottaNyBehandlingRoute
+import no.nav.tiltakspenger.datadeling.meldekort.db.MeldeperiodeRepo
+import no.nav.tiltakspenger.datadeling.meldekort.motta.routes.mottaMeldeperioderRoute
 import no.nav.tiltakspenger.datadeling.vedtak.motta.MottaNyttVedtakService
 import no.nav.tiltakspenger.datadeling.vedtak.motta.routes.mottaNyttVedtakRoute
 import java.time.Clock
@@ -11,7 +13,9 @@ fun Route.mottaRoutes(
     mottaNyttVedtakService: MottaNyttVedtakService,
     mottaNyBehanlingService: MottaNyBehandlingService,
     clock: Clock,
+    meldeperiodeRepo: MeldeperiodeRepo,
 ) {
     this.mottaNyttVedtakRoute(mottaNyttVedtakService, clock)
     this.mottaNyBehandlingRoute(mottaNyBehanlingService, clock)
+    this.mottaMeldeperioderRoute(meldeperiodeRepo)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/datadeling/vedtak/db/VedtakRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/datadeling/vedtak/db/VedtakRepo.kt
@@ -178,7 +178,7 @@ class VedtakRepo(
         vedtakId = row.string("vedtak_id"),
         sakId = row.string("sak_id"),
         saksnummer = row.string("saksnummer"),
-        fnr = Fnr.Companion.fromString(row.string("fnr")),
+        fnr = Fnr.fromString(row.string("fnr")),
         periode = Periode(
             row.localDate("fra_og_med"),
             row.localDate("til_og_med"),

--- a/src/main/resources/db/migration/V11__create_meldeperiode.sql
+++ b/src/main/resources/db/migration/V11__create_meldeperiode.sql
@@ -1,6 +1,6 @@
 CREATE TABLE meldeperiode
 (
-    id                            varchar PRIMARY KEY,
+    id                            varchar                  NOT NULL,
     kjede_id                      varchar                  NOT NULL,
     sak_id                        varchar                  NOT NULL,
     saksnummer                    varchar                  NOT NULL,
@@ -10,8 +10,7 @@ CREATE TABLE meldeperiode
     til_og_med                    DATE                     NOT NULL,
     maks_antall_dager_for_periode INTEGER                  NOT NULL,
     gir_rett                      JSONB                    NOT NULL,
-
-    CONSTRAINT unique_kjede_id_opprettet UNIQUE (sak_id, kjede_id)
+    primary key (kjede_id, sak_id)
 );
 
 CREATE INDEX idx_meldeperiode_fnr_fra_og_med_til_og_med ON meldeperiode (fnr, fra_og_med, til_og_med);

--- a/src/main/resources/db/migration/V11__create_meldeperiode.sql
+++ b/src/main/resources/db/migration/V11__create_meldeperiode.sql
@@ -1,0 +1,17 @@
+CREATE TABLE meldeperiode
+(
+    id                            varchar PRIMARY KEY,
+    kjede_id                      varchar                  NOT NULL,
+    sak_id                        varchar                  NOT NULL,
+    saksnummer                    varchar                  NOT NULL,
+    fnr                           varchar                  NOT NULL,
+    opprettet                     timestamp with time zone NOT NULL,
+    fra_og_med                    DATE                     NOT NULL,
+    til_og_med                    DATE                     NOT NULL,
+    maks_antall_dager_for_periode INTEGER                  NOT NULL,
+    gir_rett                      JSONB                    NOT NULL,
+
+    CONSTRAINT unique_kjede_id_opprettet UNIQUE (sak_id, kjede_id)
+);
+
+CREATE INDEX idx_meldeperiode_fnr_fra_og_med_til_og_med ON meldeperiode (fnr, fra_og_med, til_og_med);

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/identhendelse/IdenthendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/identhendelse/IdenthendelseServiceTest.kt
@@ -16,7 +16,8 @@ class IdenthendelseServiceTest {
         withMigratedDb { testDataHelper ->
             val behandlingRepo = testDataHelper.behandlingRepo
             val vedtakRepo = testDataHelper.vedtakRepo
-            val identhendelseService = IdenthendelseService(behandlingRepo, vedtakRepo)
+            val meldeperiodeRepo = testDataHelper.meldeperiodeRepo
+            val identhendelseService = IdenthendelseService(behandlingRepo, vedtakRepo, meldeperiodeRepo)
 
             val gammeltFnr = Fnr.random()
             val nyttFnr = Fnr.random()

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/meldekort/db/MeldeperiodeRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/meldekort/db/MeldeperiodeRepoTest.kt
@@ -1,0 +1,152 @@
+package no.nav.tiltakspenger.datadeling.meldekort.db
+
+import io.kotest.matchers.shouldBe
+import no.nav.tiltakspenger.datadeling.meldekort.domene.Meldeperiode
+import no.nav.tiltakspenger.datadeling.testdata.MeldeperiodeMother
+import no.nav.tiltakspenger.datadeling.testutils.shouldBeCloseTo
+import no.nav.tiltakspenger.datadeling.testutils.withMigratedDb
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+class MeldeperiodeRepoTest {
+    @Test
+    fun `kan lagre og hente meldeperiode`() {
+        withMigratedDb { testDataHelper ->
+            val meldeperiodeRepo = testDataHelper.meldeperiodeRepo
+            val meldeperiode = MeldeperiodeMother.meldeperiode()
+
+            meldeperiodeRepo.lagre(listOf(meldeperiode))
+
+            val meldeperioderFraDb = meldeperiodeRepo.hentForFnrOgPeriode(
+                meldeperiode.fnr,
+                Periode(
+                    fraOgMed = meldeperiode.fraOgMed.minusDays(5),
+                    tilOgMed = meldeperiode.tilOgMed.plusDays(5),
+                ),
+            )
+
+            meldeperioderFraDb.size shouldBe 1
+            val meldeperiodeFraDb = meldeperioderFraDb.first()
+            sammenlignMeldeperiode(meldeperiodeFraDb, meldeperiode)
+        }
+    }
+
+    @Test
+    fun `lagrer ikke meldeperiode hvis ingen dager gir rett`() {
+        withMigratedDb { testDataHelper ->
+            val meldeperiodeRepo = testDataHelper.meldeperiodeRepo
+            val periode = MeldeperiodeMother.periode()
+            val meldeperiode = MeldeperiodeMother.meldeperiode(
+                periode = periode,
+                girRett = periode.tilDager().associateWith { false },
+            )
+
+            meldeperiodeRepo.lagre(listOf(meldeperiode))
+
+            val meldeperioderFraDb = meldeperiodeRepo.hentForFnrOgPeriode(
+                meldeperiode.fnr,
+                Periode(
+                    fraOgMed = meldeperiode.fraOgMed.minusDays(5),
+                    tilOgMed = meldeperiode.tilOgMed.plusDays(5),
+                ),
+            )
+
+            meldeperioderFraDb.size shouldBe 0
+        }
+    }
+
+    @Test
+    fun `oppdaterer eksisterende meldeperioder`() {
+        withMigratedDb { testDataHelper ->
+            val meldeperiodeRepo = testDataHelper.meldeperiodeRepo
+            val meldeperiode = MeldeperiodeMother.meldeperiode()
+
+            meldeperiodeRepo.lagre(listOf(meldeperiode))
+
+            val girRett = Periode(
+                fraOgMed = meldeperiode.fraOgMed,
+                tilOgMed = meldeperiode.tilOgMed,
+            ).tilDager()
+                .associateWith { value ->
+                    listOf(value.dayOfWeek).none { it == DayOfWeek.SATURDAY || it == DayOfWeek.SUNDAY } && value.isBefore(
+                        meldeperiode.tilOgMed.minusDays(4),
+                    )
+                }
+            val oppdatertMeldeperiode = meldeperiode.copy(
+                girRett = girRett,
+                maksAntallDagerForPeriode = girRett.filter { it.value }.size,
+            )
+
+            meldeperiodeRepo.lagre(listOf(oppdatertMeldeperiode))
+
+            val meldeperioderFraDb = meldeperiodeRepo.hentForFnrOgPeriode(
+                meldeperiode.fnr,
+                Periode(
+                    fraOgMed = meldeperiode.fraOgMed.minusDays(5),
+                    tilOgMed = meldeperiode.tilOgMed.plusDays(5),
+                ),
+            )
+
+            meldeperioderFraDb.size shouldBe 1
+            val meldeperiodeFraDb = meldeperioderFraDb.first()
+            sammenlignMeldeperiode(meldeperiodeFraDb, oppdatertMeldeperiode)
+        }
+    }
+
+    @Test
+    fun `sletter eksisterende meldeperiode hvis ingen dager gir rett`() {
+        withMigratedDb { testDataHelper ->
+            val meldeperiodeRepo = testDataHelper.meldeperiodeRepo
+            val forstePeriode = MeldeperiodeMother.periode(
+                fraSisteMandagFor = LocalDate.now().minusDays(14),
+                tilSisteSondagEtter = null,
+            )
+            val meldeperiode1 = MeldeperiodeMother.meldeperiode(periode = forstePeriode)
+            val andrePeriode =
+                MeldeperiodeMother.periode(fraSisteMandagFor = LocalDate.now(), tilSisteSondagEtter = null)
+            val meldeperiode2 = MeldeperiodeMother.meldeperiode(
+                periode = andrePeriode,
+                sakId = meldeperiode1.sakId,
+            )
+
+            meldeperiodeRepo.lagre(listOf(meldeperiode1, meldeperiode2))
+
+            val oppdatertMeldeperiode = meldeperiode2.copy(
+                girRett = Periode(
+                    fraOgMed = meldeperiode2.fraOgMed,
+                    tilOgMed = meldeperiode2.tilOgMed,
+                ).tilDager().associateWith { false },
+                maksAntallDagerForPeriode = 0,
+            )
+
+            meldeperiodeRepo.lagre(listOf(meldeperiode1, oppdatertMeldeperiode))
+
+            val meldeperioderFraDb = meldeperiodeRepo.hentForFnrOgPeriode(
+                meldeperiode1.fnr,
+                Periode(
+                    fraOgMed = meldeperiode1.fraOgMed.minusDays(5),
+                    tilOgMed = meldeperiode2.tilOgMed.plusDays(5),
+                ),
+            )
+
+            meldeperioderFraDb.size shouldBe 1
+            val meldeperiodeFraDb = meldeperioderFraDb.first()
+            sammenlignMeldeperiode(meldeperiodeFraDb, meldeperiode1)
+        }
+    }
+
+    private fun sammenlignMeldeperiode(actual: Meldeperiode, expected: Meldeperiode) {
+        actual.id shouldBe expected.id
+        actual.kjedeId shouldBe expected.kjedeId
+        actual.fnr shouldBe expected.fnr
+        actual.sakId shouldBe expected.sakId
+        actual.saksnummer shouldBe expected.saksnummer
+        actual.opprettet shouldBeCloseTo expected.opprettet
+        actual.fraOgMed shouldBe expected.fraOgMed
+        actual.tilOgMed shouldBe expected.tilOgMed
+        actual.maksAntallDagerForPeriode shouldBe expected.maksAntallDagerForPeriode
+        actual.girRett shouldBe expected.girRett
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/meldekort/db/MeldeperiodeRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/meldekort/db/MeldeperiodeRepoTest.kt
@@ -5,6 +5,7 @@ import no.nav.tiltakspenger.datadeling.meldekort.domene.Meldeperiode
 import no.nav.tiltakspenger.datadeling.testdata.MeldeperiodeMother
 import no.nav.tiltakspenger.datadeling.testutils.shouldBeCloseTo
 import no.nav.tiltakspenger.datadeling.testutils.withMigratedDb
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
@@ -75,6 +76,7 @@ class MeldeperiodeRepoTest {
                     )
                 }
             val oppdatertMeldeperiode = meldeperiode.copy(
+                id = MeldeperiodeId.random(),
                 girRett = girRett,
                 maksAntallDagerForPeriode = girRett.filter { it.value }.size,
             )
@@ -114,6 +116,7 @@ class MeldeperiodeRepoTest {
             meldeperiodeRepo.lagre(listOf(meldeperiode1, meldeperiode2))
 
             val oppdatertMeldeperiode = meldeperiode2.copy(
+                id = MeldeperiodeId.random(),
                 girRett = Periode(
                     fraOgMed = meldeperiode2.fraOgMed,
                     tilOgMed = meldeperiode2.tilOgMed,

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/testdata/MeldeperiodeMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/testdata/MeldeperiodeMother.kt
@@ -1,0 +1,57 @@
+package no.nav.tiltakspenger.datadeling.testdata
+
+import no.nav.tiltakspenger.datadeling.meldekort.domene.Meldeperiode
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.TemporalAdjusters
+
+object MeldeperiodeMother {
+    fun meldeperiode(
+        id: MeldeperiodeId = MeldeperiodeId.random(),
+        periode: Periode = periode(),
+        kjedeId: MeldeperiodeKjedeId = MeldeperiodeKjedeId.fraPeriode(periode),
+        fnr: Fnr = Fnr.fromString("12345678901"),
+        sakId: SakId = SakId.random(),
+        saksnummer: String = "saksnummer",
+        opprettet: LocalDateTime? = null,
+        girRett: Map<LocalDate, Boolean> = periode.tilGirRett(),
+        antallDagerForPeriode: Int = girRett.filter { it.value }.size,
+    ): Meldeperiode {
+        require(MeldeperiodeKjedeId.fraPeriode(periode) == kjedeId) {
+            "KjedeId må være lik MeldeperiodeKjedeId.fraPeriode(periode)"
+        }
+        return Meldeperiode(
+            id = id,
+            kjedeId = kjedeId.verdi,
+            fnr = fnr,
+            sakId = sakId,
+            saksnummer = saksnummer,
+            opprettet = opprettet ?: LocalDateTime.now(),
+            fraOgMed = periode.fraOgMed,
+            tilOgMed = periode.tilOgMed,
+            maksAntallDagerForPeriode = antallDagerForPeriode,
+            girRett = girRett,
+        )
+    }
+
+    fun periode(fraSisteMandagFor: LocalDate = LocalDate.now(), tilSisteSondagEtter: LocalDate? = null): Periode {
+        if (tilSisteSondagEtter != null) {
+            return tilSisteSondagEtter.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)).let { sondag ->
+                Periode(sondag.minusDays(13), sondag)
+            }
+        }
+
+        return fraSisteMandagFor.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).let { mandag ->
+            Periode(mandag, mandag.plusDays(13))
+        }
+    }
+
+    private fun Periode.tilGirRett(): Map<LocalDate, Boolean> = tilDager()
+        .associateWith { value -> listOf(value.dayOfWeek).none { it == DayOfWeek.SATURDAY || it == DayOfWeek.SUNDAY } }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/testdata/VedtakMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/testdata/VedtakMother.kt
@@ -16,7 +16,7 @@ object VedtakMother {
         vedtakId: String = UUID.randomUUID().toString(),
         sakId: String = "sakId",
         saksnummer: String = "saksnummer",
-        fnr: Fnr = Fnr.Companion.fromString("12345678901"),
+        fnr: Fnr = Fnr.fromString("12345678901"),
         mottattTidspunkt: LocalDateTime = LocalDateTime.parse("2021-01-01T00:00:00.000"),
         opprettetTidspunkt: LocalDateTime = LocalDateTime.parse("2021-01-01T00:00:00.000"),
         barnetillegg: Barnetillegg? = null,

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/testutils/DateTimeAssertions.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/testutils/DateTimeAssertions.kt
@@ -1,0 +1,14 @@
+package no.nav.tiltakspenger.datadeling.testutils
+
+import io.kotest.matchers.date.shouldBeWithin
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.LocalDateTime
+
+infix fun LocalDateTime?.shouldBeCloseTo(expected: LocalDateTime?) {
+    if (this == null) {
+        expected shouldBe null
+    } else {
+        expected!!.shouldBeWithin(Duration.ofSeconds(10), this)
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/testutils/TestDataHelper.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/testutils/TestDataHelper.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.datadeling.testutils
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.datadeling.behandling.db.BehandlingRepo
+import no.nav.tiltakspenger.datadeling.meldekort.db.MeldeperiodeRepo
 import no.nav.tiltakspenger.datadeling.vedtak.db.VedtakRepo
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.SessionCounter
@@ -15,6 +16,7 @@ internal class TestDataHelper(
     val sessionFactory = PostgresSessionFactory(dataSource, sessionCounter)
     val vedtakRepo = VedtakRepo(sessionFactory)
     val behandlingRepo = BehandlingRepo(sessionFactory)
+    val meldeperiodeRepo = MeldeperiodeRepo(sessionFactory)
 }
 
 private val dbManager = TestDatabaseManager()

--- a/src/test/kotlin/no/nav/tiltakspenger/datadeling/testutils/TestDatabaseManager.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/datadeling/testutils/TestDatabaseManager.kt
@@ -79,7 +79,8 @@ internal class TestDatabaseManager {
                 """
                 TRUNCATE
                   rammevedtak,
-                  behandling
+                  behandling,
+                  meldeperiode
                 """.trimIndent(),
             ).asUpdate,
         )


### PR DESCRIPTION
Api for å ta i mot meldeperioder fra saksbehandlingsapi og lagre dem. Tanken min er at vi lagrer alle meldeperioder der minst en dag gir rett i en tabell, og at vi har en annen tabell som er koblet til meldeperiode via meldeperiodeId der vi lagrer godkjente meldekort. Api for å dele data med konsumenter skal helst kunne hente både meldeperioder og evt godkjente meldekort med kun en spørring, og basert på fnr og periode som input. 

Antagelser: 
- meldeperiodeId endres ikke (hvis den gjør det må jeg endre slik at jeg bruker sakId + kjedeId, men siden dette her ligner på det som skjer i meldekort-api tror jeg kanskje det bør fungere)

https://trello.com/c/2PCK4icK/1683-nks-salesforce-trenger-data-om-meldekort